### PR TITLE
Initialize build number before dark mode check

### DIFF
--- a/src/DarkMode.cpp
+++ b/src/DarkMode.cpp
@@ -277,6 +277,8 @@ void DarkModeHelper::InitDarkMode()
 	if (!getOSVersionNumber(major, minor, buildNumber))
 		return;
 
+	g_buildNumber = buildNumber;
+
 	if (major == 10 && minor == 0 && g_buildNumber >= MinSupportVersion)
 	{
 		const ModuleHandle moduleUxtheme(L"uxtheme.dll");


### PR DESCRIPTION
This change broke the library:

https://github.com/anthonyleestark/darkmode32plus/commit/4bf878bbeac8e93a3e99b9d1b70229b4eb866ccc

When ripping out old code, you neglected to update g_buildNumber, and it never budged from zero, failing the OS capability test. 

Awesome library, just trying to give back a bit.


